### PR TITLE
Add /api/info endpoint

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,8 @@ The API exposes the following methods:
 +-------------+---------------------------------------------+
 | inquiry     | Lookup a matching address given a zip9.     |
 +-------------+---------------------------------------------+
+| info        | Get USPS AMS library information            |
++-------------+---------------------------------------------+
 
 Validate
 ~~~~~~~~
@@ -323,6 +325,29 @@ Usage::
     /api/inquiry?zip5=12180&zip4=1928
 
 The output is exactly identical to the validate method so it won't be reproduced here.
+
+Info
+~~~~
+
+This method returns information about the USPS AMS library underlying the API. Specifically
+
+- `apiVersion`
+- `dataExpireDays`
+- `libraryExpireDays`
+
+There are no query parameters.
+
+Usage::
+
+    /api/info
+
+Output::
+
+    {
+      "apiVersion" : "3.03.05.N",
+      "dataExpireDays" : 103,
+      "libraryExpireDays" : 529
+    }
 
 Batch API Methods
 -----------------

--- a/src/main/java/gov/nysenate/ams/client/response/LibraryInfoResponse.java
+++ b/src/main/java/gov/nysenate/ams/client/response/LibraryInfoResponse.java
@@ -1,0 +1,27 @@
+package gov.nysenate.ams.client.response;
+
+public class LibraryInfoResponse
+{
+	protected String apiVersion;
+	protected int dataExpireDays;
+	protected int libraryExpireDays;
+
+	public LibraryInfoResponse(String apiVersion, int dataExpireDays, int libraryExpireDays)
+	{
+		this.apiVersion = apiVersion;
+		this.dataExpireDays = dataExpireDays;
+		this.libraryExpireDays = libraryExpireDays;
+	}
+
+	public String getApiVersion() {
+		return apiVersion;
+	}
+
+	public int getDataExpireDays() {
+		return dataExpireDays;
+	}
+
+	public int getLibraryExpireDays() {
+		return libraryExpireDays;
+	}
+}

--- a/src/main/java/gov/nysenate/ams/controller/LibraryInfoController.java
+++ b/src/main/java/gov/nysenate/ams/controller/LibraryInfoController.java
@@ -1,0 +1,54 @@
+package gov.nysenate.ams.controller;
+
+import gov.nysenate.ams.client.response.LibraryInfoResponse;
+import gov.nysenate.ams.filter.ApiFilter;
+import gov.nysenate.ams.provider.AmsNativeProvider;
+import gov.nysenate.ams.util.Application;
+import org.apache.log4j.Logger;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Servlet to handle library info requests.
+ */
+public class LibraryInfoController extends BaseApiController
+{
+    private Logger logger = Logger.getLogger(LibraryInfoController.class);
+    private AmsNativeProvider amsNativeProvider;
+
+    @Override
+    public void init(ServletConfig config) throws ServletException
+    {
+        this.amsNativeProvider = Application.getAmsNativeProvider();
+        logger.debug("Initialized LibraryInfoController.");
+    }
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+        processRequest(request, response);
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+        processRequest(request, response);
+    }
+
+    private void processRequest(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+    {
+        Object responseObj;
+
+        String apiVersion = amsNativeProvider.getApiVersion();
+        int dataExpireDays = amsNativeProvider.getDataExpireDays();
+        int libraryExpireDays = amsNativeProvider.getLibraryExpireDays();
+
+        responseObj = new LibraryInfoResponse(apiVersion, dataExpireDays, libraryExpireDays);
+
+        ApiFilter.setApiResponse(responseObj, request);
+    }
+}

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -56,4 +56,14 @@
         <url-pattern>/api/citystate/*</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <display-name>LibraryInfoController</display-name>
+        <servlet-name>LibraryInfoController</servlet-name>
+        <servlet-class>gov.nysenate.ams.controller.LibraryInfoController</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>LibraryInfoController</servlet-name>
+        <url-pattern>/api/info/*</url-pattern>
+    </servlet-mapping>
+
 </web-app>


### PR DESCRIPTION
The endpoint returns the following library information

- libraryExpireDays
- dataExpireDays
- apiVersion

@kzalewski I'm not the most experienced in java, so if there are changes you'd like please let me know. I've tested it successfully locally.

Here's an example of the output (json-formatted by my browser)
![image](https://user-images.githubusercontent.com/2916004/36336722-2d12bc4a-133f-11e8-89c1-7be4963fb679.png)
